### PR TITLE
Fixed Trakt rebuild database broke, and some modifications to sorting results from trakt

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.seren" version="3.0.62d" name="Seren" provider-name="Nixgates">
+<addon id="plugin.video.seren" version="3.0.63" name="Seren" provider-name="Nixgates">
     <requires>
         <import addon="xbmc.addon" version="17.9.910" />
         <import addon="xbmc.python" version="3.0.0" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+Changelog 3.0.63
+[BUG] Rebuild Trakt database was broken, and implemented better way to handle sorting
+
+Changelog 3.0.62d
+[BUG] Further RD fix implementation
+
 Changelog 3.0.62
 [BUG] Optimised RD fix implementation
 [BUG] Improved RD season pack handling

--- a/resources/lib/database/trakt_sync/activities.py
+++ b/resources/lib/database/trakt_sync/activities.py
@@ -141,14 +141,9 @@ class TraktSyncDatabase(trakt_sync.TraktSyncDatabase):
 
 		if not self.sync_errors:
 			self._update_activity_record("all_activities", update_time)
-			#xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=widgetRefresh&playing=False")')
-			if_playing = params.get('playing')
-			if if_playing is not None:
-				if_playing = False if if_playing.lower() == "false" else True if if_playing.lower() == "true" else None
-			if if_playing is not None:
-				g.trigger_widget_refresh(if_playing=if_playing)
-			else:
-				g.trigger_widget_refresh()
+			xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=widgetRefresh&playing=False")')
+
+
 
 	def _do_sync_acitivites(self, remote_activities):
 		total_activities = len(self._sync_activities_list)

--- a/resources/lib/indexers/trakt.py
+++ b/resources/lib/indexers/trakt.py
@@ -780,47 +780,38 @@ class TraktAPI(ApiBase):
 			return items
 
 		supported_sorts = [
-			"added",
-			"rank",
-			"title",
-			"released",
-			"runtime",
-			"popularity",
-			"votes",
-			"random",
-			"runtime",
-			"percentage",
-			"watched",
-			"collected",
+			"added", "rank", "title", "released", "runtime", "popularity",
+			"votes", "random", "runtime", "percentage", "watched", "collected",
 			"my_rating",
 		]
 
+		# Validate the sort_by key
 		if sort_by not in supported_sorts:
-			g.log(f"Error sorting trakt response: Unsupported sort_by ({sort_by})", "error")
-			return items
+			g.log(f"Unsupported sort_by ({sort_by}). Defaulting to 'rank'.", "warning")
+			sort_by = "rank"  # Default to a valid key
 
-		if sort_by == "added":
-			items = sorted(items, key=lambda x: x.get("listed_at"))
-		elif sort_by == "rank":
-			items = sorted(items, key=lambda x: x.get("rank"))
+		# Sorting logic with None handling
+		if sort_by == "rank":
+			items = sorted(items, key=lambda x: x.get("rank") or 0)  # Default rank to 0
+		elif sort_by == "added":
+			items = sorted(items, key=lambda x: x.get("listed_at") or "")
 		elif sort_by == "title":
 			items = sorted(items, key=self._title_sorter)
 		elif sort_by == "released":
 			items = sorted(items, key=self._released_sorter)
 		elif sort_by == "runtime":
-			items = sorted(items, key=lambda x: x[x["type"]].get("runtime"))
+			items = sorted(items, key=lambda x: x[x["type"]].get("runtime") or 0)
 		elif sort_by == "popularity":
 			items = sorted(
 				items,
 				key=lambda x: float(x[x["type"]].get("rating", 0) * int(x[x["type"]].get("votes", 0))),
 			)
 		elif sort_by == "votes":
-			items = sorted(items, key=lambda x: x[x["type"]].get("votes"))
+			items = sorted(items, key=lambda x: x[x["type"]].get("votes") or 0)
 		elif sort_by == "percentage":
-			items = sorted(items, key=lambda x: x[x["type"]].get("rating"))
+			items = sorted(items, key=lambda x: x[x["type"]].get("rating") or 0)
 		elif sort_by == "random":
 			import random
-
 			random.shuffle(items)
 		elif sort_by == "watched":
 			items = self._watched_sort(items)
@@ -833,6 +824,8 @@ class TraktAPI(ApiBase):
 			items.reverse()
 
 		return items
+
+
 
 	@staticmethod
 	def _title_sorter(item):

--- a/service.py
+++ b/service.py
@@ -7,8 +7,8 @@ import xbmc
 from resources.lib.common import tools
 
 if tools.is_stub():
-	# noinspection PyUnresolvedReferences
-	from mock_kodi import MOCK
+    # noinspection PyUnresolvedReferences
+    from mock_kodi import MOCK
 
 from resources.lib.modules.globals import g
 
@@ -31,50 +31,31 @@ g.log("#############  SERVICE ENTERED KEEP ALIVE  #################")
 
 monitor = SerenMonitor()
 try:
-	xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=longLifeServiceManager")')
-	#g.log("plugin://plugin.video.seren/?action=longLifeServiceManager")
-	#from resources.lib.modules.providers.service_manager import (
-	#	ProvidersServiceManager,
-	#)
-	#ProvidersServiceManager().run_long_life_manager()
+    xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=longLifeServiceManager")')
 
-	#do_update_news()
-	validate_timezone_detected()
-	try:
-		g.clear_kodi_bookmarks()
-	except TypeError:
-		g.log(
-			"Unable to clear bookmarks on service init. This is not a problem if it occurs immediately after install.",
-			"warning",
-		)
+    do_update_news()
+    validate_timezone_detected()
+    try:
+        g.clear_kodi_bookmarks()
+    except TypeError:
+        g.log(
+            "Unable to clear bookmarks on service init. This is not a problem if it occurs immediately after install.",
+            "warning",
+        )
 
-	#xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=torrentCacheCleanup")')
-	g.log("plugin://plugin.video.seren/?action=torrentCacheCleanup")
-	from resources.lib.database import torrentCache
-	torrentCache.TorrentCache().do_cleanup()
+    xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=torrentCacheCleanup")')
 
-	from resources.lib.common.maintenance import run_maintenance
-	from resources.lib.database.trakt_sync.activities import TraktSyncDatabase
-	from resources.lib.database import trakt_sync
-	g.wait_for_abort(30)  # Sleep for a half a minute to allow widget loads to complete.
-	while not monitor.abortRequested():
-		#xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=runMaintenance")')
-		g.log("plugin://plugin.video.seren/?action=runMaintenance")
-		run_maintenance()
-		if not g.wait_for_abort(15):  # Sleep to make sure tokens refreshed during maintenance
-			#xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=syncTraktActivities")')
-			g.log("plugin://plugin.video.seren/?action=syncTraktActivities")
-			TraktSyncDatabase().sync_activities()
-		if not g.wait_for_abort(15):  # Sleep to make sure we don't possibly clobber settings
-			#xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=cleanOrphanedMetadata")')
-			g.log("plugin://plugin.video.seren/?action=cleanOrphanedMetadata")
-			trakt_sync.TraktSyncDatabase().flush_activities()
-		if not g.wait_for_abort(15):  # Sleep to make sure we don't possibly clobber settings
-			#xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=updateLocalTimezone")')
-			g.log("plugin://plugin.video.seren/?action=updateLocalTimezone")
-			g.init_local_timezone()
-		if g.wait_for_abort(60 * randint(13, 17)):
-			break
+    g.wait_for_abort(30)  # Sleep for a half a minute to allow widget loads to complete.
+    while not monitor.abortRequested():
+        xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=runMaintenance")')
+        if not g.wait_for_abort(15):  # Sleep to make sure tokens refreshed during maintenance
+            xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=syncTraktActivities")')
+        if not g.wait_for_abort(15):  # Sleep to make sure we don't possibly clobber settings
+            xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=cleanOrphanedMetadata")')
+        if not g.wait_for_abort(15):  # Sleep to make sure we don't possibly clobber settings
+            xbmc.executebuiltin('RunPlugin("plugin://plugin.video.seren/?action=updateLocalTimezone")')
+        if g.wait_for_abort(60 * randint(13, 17)):
+            break
 finally:
-	del monitor
-	g.deinit()
+    del monitor
+    g.deinit()


### PR DESCRIPTION
Fixed Trakt rebuild database error that for some reason broke. Never worked. Now its rebuilding as usual, as the 3.0.62 from https://github.com/bbviking/plugin.video.seren.git it worked there

And finally the sorting issues added fallback for sort_by. (got errors in log)
As i understand and with little help of AI  

Why Does or 0 Matter?

The addition of or 0 ensures that None values in the rank field do not cause a TypeError during sorting.
Without or 0:

    If any item has None for the rank field, Python raises a TypeError because it cannot compare NoneType with integers.
    This happened in your earlier logs:

    TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'

With or 0:

    Any None value is replaced with 0 during sorting.
    This ensures that sorting can proceed even if some items have missing or incomplete data.

Trade-Off:

    3.0.62: Relies on all items having valid rank values. If any are missing, the plugin crashes.
    3.0.62d (our approach): More robust, as it gracefully handles missing data by assigning a default value (0).